### PR TITLE
Update gadget-setup.sh - bind mount operation to attach other mount point

### DIFF
--- a/gadget-setup.sh
+++ b/gadget-setup.sh
@@ -20,8 +20,8 @@ UDC=ci_hdrc.0                                                     #  name of the
 
 # gadget configuration
 modprobe libcomposite                                             #  load configfs
-mount -t configfs none /config || { \                             #  mount configfs as type configfs to /config or from /sys/kernel/config (bind operation)
-  mkdir /config && mount --rbind -t configfs /sys/kernel/config /config; }
+mount -t configfs none /config || {  mkdir /config &&             \
+  mount --rbind -t configfs /sys/kernel/config /config; }         #  mount configfs as type configfs to /config or from /sys/kernel/config (bind operation)
 mkdir /config/usb_gadget/keyboardgadget                           #  make a new gadget skeleton
 cd /config/usb_gadget/keyboardgadget                              #  cd to gadget dir
 mkdir configs/c.1                                                 #  make the skeleton for a config for this gadget

--- a/gadget-setup.sh
+++ b/gadget-setup.sh
@@ -20,7 +20,8 @@ UDC=ci_hdrc.0                                                     #  name of the
 
 # gadget configuration
 modprobe libcomposite                                             #  load configfs
-mount none /config -t configfs                                    #  mount configfs as type configfs at /config
+mount -t configfs none /config || { \                             #  mount configfs as type configfs to /config or from /sys/kernel/config (bind operation)
+  mkdir /config && mount --rbind -t configfs /sys/kernel/config /config
 mkdir /config/usb_gadget/keyboardgadget                           #  make a new gadget skeleton
 cd /config/usb_gadget/keyboardgadget                              #  cd to gadget dir
 mkdir configs/c.1                                                 #  make the skeleton for a config for this gadget

--- a/gadget-setup.sh
+++ b/gadget-setup.sh
@@ -21,7 +21,7 @@ UDC=ci_hdrc.0                                                     #  name of the
 # gadget configuration
 modprobe libcomposite                                             #  load configfs
 mount -t configfs none /config || { \                             #  mount configfs as type configfs to /config or from /sys/kernel/config (bind operation)
-  mkdir /config && mount --rbind -t configfs /sys/kernel/config /config
+  mkdir /config && mount --rbind -t configfs /sys/kernel/config /config; }
 mkdir /config/usb_gadget/keyboardgadget                           #  make a new gadget skeleton
 cd /config/usb_gadget/keyboardgadget                              #  cd to gadget dir
 mkdir configs/c.1                                                 #  make the skeleton for a config for this gadget


### PR DESCRIPTION
Hello 👋. Please take my changes to _gadget-setup.sh_.

> mount configfs as type configfs to /config or from /sys/kernel/config (bind operation to attach original mount point)